### PR TITLE
Bug/related items workflow

### DIFF
--- a/src/Project/Common/serialization/Project.Templates/Habitat Sites/Common/Page/__Standard Values.yml
+++ b/src/Project/Common/serialization/Project.Templates/Habitat Sites/Common/Page/__Standard Values.yml
@@ -43,7 +43,7 @@ Languages:
       Value: 20171027T151048Z
     - ID: "3e431de1-525e-47a3-b6b0-1ccbec3a8c98"
       Hint: __Workflow state
-      Value: "{FF509B64-B6D4-4FB7-9718-C4218B992740}"
+      Value: 
     - ID: "e2a634fd-5177-46de-b629-5393caed77d7"
       Hint: Title
       Value: $name

--- a/src/Project/HabitatHome/serialization/Content/8e28955b-1fc0-4184-9d47-97e2254af698/A Wide Array of Guide Interests.yml
+++ b/src/Project/HabitatHome/serialization/Content/8e28955b-1fc0-4184-9d47-97e2254af698/A Wide Array of Guide Interests.yml
@@ -5,6 +5,9 @@ Template: "2b35e65c-137a-4641-b683-d223ca7cfac0"
 Path: /sitecore/content/Habitat Sites/Habitat Home/Data/Snippets/Two Column Snippets for Home and L1 pages/A Wide Array of Guide Interests
 DB: master
 SharedFields:
+- ID: "a4f985d9-98b3-4b52-aaaf-4344f6e747c6"
+  Hint: __Workflow
+  Value: "{C6EBE5E6-BCE3-4BAB-A5F9-16382F8369FE}"
 - ID: "f1a1fe9e-a60c-4ddb-a3a0-bb5b29fe732e"
   Hint: __Renderings
   Type: layout
@@ -331,8 +334,10 @@ SharedFields:
         <r
           uid="{EB82EF4D-3B00-44ED-BF55-BDD520D43B28}"
           p:after="*[1=2]"
-          s:ds="{874ED455-AF6F-438D-BEA8-1916B7FAB5BD}"
+          s:cnd=""
+          s:ds=""
           s:id="{896A2C68-1362-4E88-8BA0-1805AE6D4837}"
+          s:mvt=""
           s:par="GridParameters=%7B113BEF7C-97E6-46CA-8CF3-916F7FAA8DE2%7D&amp;BackgroundImage&amp;Styles=%7B45645D8F-56A4-460A-B5FB-51709FEFCE52%7D%7C%7B3D258225-9410-4FAF-A516-43490258337D%7D&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=1"
           s:ph="section-content" />
       </d>
@@ -345,3 +350,6 @@ Languages:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: 20180801T140951Z
+    - ID: "3e431de1-525e-47a3-b6b0-1ccbec3a8c98"
+      Hint: __Workflow state
+      Value: "{E93E190F-3398-489D-B3A3-A3B0D9BB33C5}"

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Snippets/Full Width CTA - Right.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Snippets/Full Width CTA - Right.yml
@@ -26,8 +26,10 @@ SharedFields:
         <r
           uid="{A83822E9-8054-4007-B80D-B2CEA0FBF56F}"
           p:after="*[1=2]"
-          s:ds="{30F50135-9BCA-436A-9C02-F3DD35A75411}"
+          s:cnd=""
+          s:ds=""
           s:id="{896A2C68-1362-4E88-8BA0-1805AE6D4837}"
+          s:mvt=""
           s:par="GridParameters=%7BF2FCE948-4F77-44AF-A188-B2030061F793%7D&amp;BackgroundImage=%3Cimage%20mediaid%3D%22%7BD355AF3D-77F9-4CEF-83AA-410B62010433%7D%22%20%2F%3E&amp;Styles=%7B45D6B71F-C87D-4CFA-8DEA-94BCACC1AE8B%7D%7C%7B197D1CF1-D544-4A23-A62E-51C60888D8B8%7D&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=1"
           s:ph="section-content" />
       </d>

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Snippets/Full Width CTA - Trainer Finder.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Snippets/Full Width CTA - Trainer Finder.yml
@@ -5,6 +5,9 @@ Template: "2b35e65c-137a-4641-b683-d223ca7cfac0"
 Path: "/sitecore/content/Habitat Sites/Habitat Home/Data/Snippets/Full Width CTA - Trainer Finder"
 DB: master
 SharedFields:
+- ID: "a4f985d9-98b3-4b52-aaaf-4344f6e747c6"
+  Hint: __Workflow
+  Value: "{C6EBE5E6-BCE3-4BAB-A5F9-16382F8369FE}"
 - ID: "c80e6f3c-5bcd-426b-b1eb-6d10672e985d"
   Hint: Data Source Selection Behavior
   Value: AskUser
@@ -26,9 +29,11 @@ SharedFields:
         <r
           uid="{A83822E9-8054-4007-B80D-B2CEA0FBF56F}"
           p:after="*[1=2]"
-          s:ds="{30F50135-9BCA-436A-9C02-F3DD35A75411}"
+          s:cnd=""
+          s:ds=""
           s:id="{896A2C68-1362-4E88-8BA0-1805AE6D4837}"
-          s:par="GridParameters={F2FCE948-4F77-44AF-A188-B2030061F793}&amp;BackgroundImage=&lt;image mediaid=&quot;{A7C5267D-4B44-4A50-B1E2-994E9CD5E327}&quot; /&gt;&amp;Styles={45D6B71F-C87D-4CFA-8DEA-94BCACC1AE8B}|{F5947911-00C7-4F00-84F4-3D748376BB32}&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=1"
+          s:mvt=""
+          s:par="GridParameters=%7BF2FCE948-4F77-44AF-A188-B2030061F793%7D&amp;BackgroundImage=%3Cimage%20mediaid%3D%22%7BA7C5267D-4B44-4A50-B1E2-994E9CD5E327%7D%22%20%2F%3E&amp;Styles=%7B45D6B71F-C87D-4CFA-8DEA-94BCACC1AE8B%7D%7C%7BF5947911-00C7-4F00-84F4-3D748376BB32%7D&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=1"
           s:ph="section-content" />
       </d>
     </r>
@@ -47,12 +52,15 @@ Languages:
             id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">
             <r
               uid="{A83822E9-8054-4007-B80D-B2CEA0FBF56F}"
-              s:par="GridParameters={F2FCE948-4F77-44AF-A188-B2030061F793}&amp;BackgroundImage=&lt;image mediaid=&quot;{5F782DD5-DFA1-4BD1-9FBB-26D4C9BA83CD}&quot; /&gt;&amp;Styles={45D6B71F-C87D-4CFA-8DEA-94BCACC1AE8B}|{F5947911-00C7-4F00-84F4-3D748376BB32}&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=1&amp;Personalization&amp;Tests" />
+              s:par="GridParameters=%7BF2FCE948-4F77-44AF-A188-B2030061F793%7D&amp;BackgroundImage=%3Cimage%20mediaid%3D%22%7B5F782DD5-DFA1-4BD1-9FBB-26D4C9BA83CD%7D%22%20%2F%3E&amp;Styles=%7B45D6B71F-C87D-4CFA-8DEA-94BCACC1AE8B%7D%7C%7BF5947911-00C7-4F00-84F4-3D748376BB32%7D&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=1" />
           </d>
         </r>
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: 20180607T133357Z
+    - ID: "3e431de1-525e-47a3-b6b0-1ccbec3a8c98"
+      Hint: __Workflow state
+      Value: "{E93E190F-3398-489D-B3A3-A3B0D9BB33C5}"
 - Language: "fr-CA"
   Versions:
   - Version: 1

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Snippets/Newsletter Signup.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Snippets/Newsletter Signup.yml
@@ -5,6 +5,9 @@ Template: "2b35e65c-137a-4641-b683-d223ca7cfac0"
 Path: /sitecore/content/Habitat Sites/Habitat Home/Data/Snippets/Newsletter Signup
 DB: master
 SharedFields:
+- ID: "a4f985d9-98b3-4b52-aaaf-4344f6e747c6"
+  Hint: __Workflow
+  Value: "{C6EBE5E6-BCE3-4BAB-A5F9-16382F8369FE}"
 - ID: "f1a1fe9e-a60c-4ddb-a3a0-bb5b29fe732e"
   Hint: __Renderings
   Type: layout
@@ -69,3 +72,6 @@ Languages:
     - ID: "25bed78c-4957-4165-998a-ca1b52f67497"
       Hint: __Created
       Value: "20180621T195031:636652074313255577Z"
+    - ID: "3e431de1-525e-47a3-b6b0-1ccbec3a8c98"
+      Hint: __Workflow state
+      Value: "{E93E190F-3398-489D-B3A3-A3B0D9BB33C5}"

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Snippets/Three Column Fitness Teasers.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Snippets/Three Column Fitness Teasers.yml
@@ -25,9 +25,11 @@ SharedFields:
         <r
           uid="{2F9872D5-856F-412C-AEB3-A7B218304779}"
           p:before="*"
-          s:ds="{18B14CF7-BAAF-4D13-931A-E8369B6F882E}"
+          s:cnd=""
+          s:ds=""
           s:id="{896A2C68-1362-4E88-8BA0-1805AE6D4837}"
-          s:par="GridParameters&amp;BackgroundImage&amp;Styles={45645D8F-56A4-460A-B5FB-51709FEFCE52}|{62BB4AA0-351C-43D1-A474-9F52EA6ECF07}|{3D258225-9410-4FAF-A516-43490258337D}&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=1"
+          s:mvt=""
+          s:par="GridParameters&amp;BackgroundImage&amp;Styles=%7B45645D8F-56A4-460A-B5FB-51709FEFCE52%7D%7C%7B62BB4AA0-351C-43D1-A474-9F52EA6ECF07%7D%7C%7B3D258225-9410-4FAF-A516-43490258337D%7D&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=1"
           s:ph="section-content" />
         <r
           uid="{8ACA1967-01B3-4F59-BB90-C931B9E9CE81}"

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Snippets/Two Column Child Tablet Teasers.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Snippets/Two Column Child Tablet Teasers.yml
@@ -18,34 +18,40 @@ SharedFields:
   Hint: __Renderings
   Type: layout
   Value: |
-    <r xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <r xmlns:p="p" xmlns:s="s"
+      p:p="1">
       <d
-        id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}"
-        l="{411E4948-E7F2-4D86-BEAD-451F79D83BCF}">
+        id="{FE5D7FDF-89C0-4D99-9AA3-B5FBD009C9F3}">
         <r
           uid="{2F9872D5-856F-412C-AEB3-A7B218304779}"
-          ds="/sitecore/content/Habitat Sites/Habitat Home/Data/Snippets/Three Column Fitness Teasers"
-          id="{896A2C68-1362-4E88-8BA0-1805AE6D4837}"
-          par="GridParameters&amp;BackgroundImage&amp;Styles={45645D8F-56A4-460A-B5FB-51709FEFCE52}|{62BB4AA0-351C-43D1-A474-9F52EA6ECF07}|{3D258225-9410-4FAF-A516-43490258337D}&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=1"
-          ph="section-content" />
+          p:before="*"
+          s:cnd=""
+          s:ds=""
+          s:id="{896A2C68-1362-4E88-8BA0-1805AE6D4837}"
+          s:mvt=""
+          s:par="GridParameters&amp;BackgroundImage&amp;Styles=%7B45645D8F-56A4-460A-B5FB-51709FEFCE52%7D%7C%7B62BB4AA0-351C-43D1-A474-9F52EA6ECF07%7D%7C%7B3D258225-9410-4FAF-A516-43490258337D%7D&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=1"
+          s:ph="section-content" />
         <r
           uid="{1E33D083-15B8-4A94-9AD3-418A558B2200}"
-          ds="/sitecore/content/Habitat Sites/Habitat Home/home/guides/watch-out-on-tablets"
-          id="{162AB463-0CE1-4295-8F7E-2E2E969984ED}"
-          par="GridParameters={113BEF7C-97E6-46CA-8CF3-916F7FAA8DE2}&amp;FieldNames={3E6E7D0C-2472-4157-B4C8-F920504A4196}&amp;Styles&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=4"
-          ph="/section-content/container-1/column-2-2" />
+          p:after="r[@uid='{2F9872D5-856F-412C-AEB3-A7B218304779}']"
+          s:ds="/sitecore/content/Habitat Sites/Habitat Home/home/guides/watch-out-on-tablets"
+          s:id="{162AB463-0CE1-4295-8F7E-2E2E969984ED}"
+          s:par="GridParameters={113BEF7C-97E6-46CA-8CF3-916F7FAA8DE2}&amp;FieldNames={3E6E7D0C-2472-4157-B4C8-F920504A4196}&amp;Styles&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=4"
+          s:ph="/section-content/container-1/column-2-2" />
         <r
           uid="{A2CF8491-0BA7-4858-8E66-8596F4903AB7}"
-          ds="/sitecore/content/Habitat Sites/Habitat Home/home/guides/the-best-child-proof-tablets-around"
-          id="{162AB463-0CE1-4295-8F7E-2E2E969984ED}"
-          par="GridParameters={113BEF7C-97E6-46CA-8CF3-916F7FAA8DE2}&amp;FieldNames={3E6E7D0C-2472-4157-B4C8-F920504A4196}&amp;Styles&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=3"
-          ph="/section-content/container-1/column-1-2" />
+          p:after="r[@uid='{1E33D083-15B8-4A94-9AD3-418A558B2200}']"
+          s:ds="/sitecore/content/Habitat Sites/Habitat Home/home/guides/the-best-child-proof-tablets-around"
+          s:id="{162AB463-0CE1-4295-8F7E-2E2E969984ED}"
+          s:par="GridParameters={113BEF7C-97E6-46CA-8CF3-916F7FAA8DE2}&amp;FieldNames={3E6E7D0C-2472-4157-B4C8-F920504A4196}&amp;Styles&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=3"
+          s:ph="/section-content/container-1/column-1-2" />
         <r
           uid="{3CB4EC45-C979-472A-905B-CAA07F72B9A7}"
-          ds="/sitecore/content/Habitat Sites/Habitat Home/Data/Snippets/Three Column Fitness Teasers"
-          id="{C25766C8-9AFD-4D28-87FE-147774F6806D}"
-          par="SplitterSize=2&amp;EnabledPlaceholders=1,2&amp;Styles1&amp;Styles2&amp;Styles3&amp;Styles4&amp;Styles5&amp;Styles6&amp;Styles7&amp;Styles8&amp;ColumnWidth1={F6DC722E-15DB-4826-920B-ACCFDA772432}&amp;ColumnWidth2={F6DC722E-15DB-4826-920B-ACCFDA772432}&amp;ColumnWidth3={4D4B771B-9954-430E-AEE1-E76C54BD50C3}&amp;ColumnWidth4&amp;ColumnWidth5&amp;ColumnWidth6&amp;ColumnWidth7&amp;ColumnWidth8&amp;Reset Caching Options&amp;DynamicPlaceholderId=2"
-          ph="/section-content/container-1" />
+          p:after="*[1=2]"
+          s:ds="/sitecore/content/Habitat Sites/Habitat Home/Data/Snippets/Three Column Fitness Teasers"
+          s:id="{C25766C8-9AFD-4D28-87FE-147774F6806D}"
+          s:par="SplitterSize=2&amp;EnabledPlaceholders=1,2&amp;Styles1&amp;Styles2&amp;Styles3&amp;Styles4&amp;Styles5&amp;Styles6&amp;Styles7&amp;Styles8&amp;ColumnWidth1={F6DC722E-15DB-4826-920B-ACCFDA772432}&amp;ColumnWidth2={F6DC722E-15DB-4826-920B-ACCFDA772432}&amp;ColumnWidth3={4D4B771B-9954-430E-AEE1-E76C54BD50C3}&amp;ColumnWidth4&amp;ColumnWidth5&amp;ColumnWidth6&amp;ColumnWidth7&amp;ColumnWidth8&amp;Reset Caching Options&amp;DynamicPlaceholderId=2"
+          s:ph="/section-content/container-1" />
       </d>
     </r>
 Languages:

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Snippets/Two Column Fitness Teasers.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Snippets/Two Column Fitness Teasers.yml
@@ -22,9 +22,11 @@ SharedFields:
         <r
           uid="{2F9872D5-856F-412C-AEB3-A7B218304779}"
           p:before="*"
-          s:ds="/sitecore/content/Habitat Sites/Habitat Home/Data/Snippets/Three Column Fitness Teasers"
+          s:cnd=""
+          s:ds=""
           s:id="{896A2C68-1362-4E88-8BA0-1805AE6D4837}"
-          s:par="GridParameters&amp;BackgroundImage&amp;Styles={45645D8F-56A4-460A-B5FB-51709FEFCE52}|{62BB4AA0-351C-43D1-A474-9F52EA6ECF07}|{3D258225-9410-4FAF-A516-43490258337D}&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=1"
+          s:mvt=""
+          s:par="GridParameters&amp;BackgroundImage&amp;Styles=%7B45645D8F-56A4-460A-B5FB-51709FEFCE52%7D%7C%7B62BB4AA0-351C-43D1-A474-9F52EA6ECF07%7D%7C%7B3D258225-9410-4FAF-A516-43490258337D%7D&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=1"
           s:ph="section-content" />
         <r
           uid="{1E33D083-15B8-4A94-9AD3-418A558B2200}"

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Snippets/Two Column Promos.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Snippets/Two Column Promos.yml
@@ -43,9 +43,11 @@ SharedFields:
         <r
           uid="{105BBB7A-AAC8-4320-B9CC-4533BF6E3C68}"
           p:after="*[1=2]"
-          s:ds="{1CDB0F8B-77AC-4939-9BD0-BFE0197DB7BC}"
+          s:cnd=""
+          s:ds=""
           s:id="{896A2C68-1362-4E88-8BA0-1805AE6D4837}"
-          s:par="GridParameters={F2FCE948-4F77-44AF-A188-B2030061F793}&amp;BackgroundImage&amp;Styles={45645D8F-56A4-460A-B5FB-51709FEFCE52}|{62BB4AA0-351C-43D1-A474-9F52EA6ECF07}|{3D258225-9410-4FAF-A516-43490258337D}&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=1"
+          s:mvt=""
+          s:par="GridParameters=%7BF2FCE948-4F77-44AF-A188-B2030061F793%7D&amp;BackgroundImage&amp;Styles=%7B45645D8F-56A4-460A-B5FB-51709FEFCE52%7D%7C%7B62BB4AA0-351C-43D1-A474-9F52EA6ECF07%7D%7C%7B3D258225-9410-4FAF-A516-43490258337D%7D&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=1"
           s:ph="section-content" />
       </d>
     </r>

--- a/src/Project/HabitatHome/serialization/Templates.Branches/Habitat Home/Landing Page/_name/Data/Two Column Promos.yml
+++ b/src/Project/HabitatHome/serialization/Templates.Branches/Habitat Home/Landing Page/_name/Data/Two Column Promos.yml
@@ -40,9 +40,11 @@ SharedFields:
         <r
           uid="{105BBB7A-AAC8-4320-B9CC-4533BF6E3C68}"
           p:after="*[1=2]"
-          s:ds="/sitecore/content/Habitat Sites/Habitat Home/Data/Snippets/Two Column Promos"
+          s:cnd=""
+          s:ds=""
           s:id="{896A2C68-1362-4E88-8BA0-1805AE6D4837}"
-          s:par="GridParameters={F2FCE948-4F77-44AF-A188-B2030061F793}&amp;BackgroundImage&amp;Styles={45645D8F-56A4-460A-B5FB-51709FEFCE52}|{62BB4AA0-351C-43D1-A474-9F52EA6ECF07}|{3D258225-9410-4FAF-A516-43490258337D}&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=1"
+          s:mvt=""
+          s:par="GridParameters=%7BF2FCE948-4F77-44AF-A188-B2030061F793%7D&amp;BackgroundImage&amp;Styles=%7B45645D8F-56A4-460A-B5FB-51709FEFCE52%7D%7C%7B62BB4AA0-351C-43D1-A474-9F52EA6ECF07%7D%7C%7B3D258225-9410-4FAF-A516-43490258337D%7D&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=1"
           s:ph="section-content" />
       </d>
     </r>


### PR DESCRIPTION
Bug fix submission in relation to #43 

I found that workflow was failing for pages with snippets due to circular references within snippet presentation data sources. This is a problem because the Advance Related Items workflow action is grabbing all data sources for related renderings and moving them along the same workflow states as the main page item. 

Each snippet I found had a "Container" component, which had a Data Source field pointing back to a snippet. I updated all pre-configured snippets under /sitecore/content/Habitat Sites/Habitat Home/Data/Snippets as well as the one under the Landing Page branch template (/sitecore/templates/Branches/Project/Habitat Sites/Habitat Home/Landing Page)

I've added extra logic to the AdvanceRelatedItems workflow action to avoid processing items outside of the /sitecore/content tree (ex. media items) as well as make sure items aren't reprocessed in cases where they are already in the workflow state of the main item

