### PR TITLE
Missing the step of Modify-Unicorn-Source-Folder

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -48,6 +48,7 @@ Task("Quick-Deploy")
 .IsDependentOn("Clean")
 .IsDependentOn("Publish-All-Projects")
 .IsDependentOn("Apply-Xml-Transform")
+.IsDependentOn("Modify-Unicorn-Source-Folder")
 .IsDependentOn("Publish-Transforms")
 .IsDependentOn("Publish-xConnect-Project");
 


### PR DESCRIPTION
Add the step **Modify-Unicorn-Source-Folder** into **Quick-Deploy**.

This steps will update the **sc.variable name="sourceFolder"** under `{webroot}\App_Config\Include\Project\z.HabitatHome.Commerce.WebSite.DevSettings.config`. Unless it cause the errors while unicorn synchronizing in the step of initializing **Sitecore.HabitatHome.Commerce**
