### PR TITLE
Removing the Habitat Home Guide Author role from DemoAdmin user

### DIFF
--- a/src/Project/Common/serialization/Users/sitecore/demoadmin.yml
+++ b/src/Project/Common/serialization/Users/sitecore/demoadmin.yml
@@ -3,7 +3,7 @@ Username: |
   sitecore\demoadmin
 Email: admin@demo.com
 Comment: Demo Administrator
-Created: "2018-04-16T14:17:31.0000000Z"
+Created: "2018-09-28T17:18:18.0000000Z"
 IsApproved: True
 Properties:
 - Key: FullName
@@ -35,7 +35,5 @@ Roles:
     sitecore\Author
   MemberOf: |
     sitecore\EXM Users
-  MemberOf: |
-    sitecore\Habitat Home Guide Author
   MemberOf: |
     sitecore\Marketing Automation Editors


### PR DESCRIPTION
This role caused issue with Unicorn sync.